### PR TITLE
Assignment - Fix Broken Maven Project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <junit.version>5.3.2</junit.version>
     </properties>
 
     <dependencies>
@@ -48,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18</version>
+                <version>2.22.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -76,3 +77,4 @@
             </plugin>
         </plugins>
     </reporting>
+</project>

--- a/src/test/java/guru/springframework/Junit5Test.java
+++ b/src/test/java/guru/springframework/Junit5Test.java
@@ -1,7 +1,6 @@
 package guru.springframework;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -9,7 +8,6 @@ import org.junit.jupiter.api.Test;
  */
 public class Junit5Test {
 
-    @Disabled
     @Test
     void someFauxTest() {
 


### PR DESCRIPTION
1. Could not read pom.xml

	Added </project> at the end of pom.xml

2. ${junit.version} doesn't exist

	Added property <junit.version>5.3.2</junit.version>

3. Only test JavaHelloWorldTest run

	Changed the version of maven-surefire-plugin to 2.22.1 so 2 test are
running now

4. test Junit5Test was skipped

	Deleted @Disabled