### PR TITLE
Fix it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <junit.version>5.4.0</junit.version>
     </properties>
 
     <dependencies>
@@ -48,12 +49,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18</version>
+                <version>3.0.0-M3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <goals>
@@ -63,7 +64,11 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -76,3 +81,4 @@
             </plugin>
         </plugins>
     </reporting>
+</project>


### PR DESCRIPTION
Fix the issues with the pom.xml so that mvn clean install site will run
successfully.

1) Fixed the issue with the missing end tag </project>
2) Fixed the missing junit version.
3) Needed to add support for reporting by adding a maven-site-plugin
version.

4) missed this one: JUnit 5 test wasn't running because maven surefire
plugin was not at a version to support it. Updated the version to be the
same as the failsafe version,and it is run.